### PR TITLE
Fix /sbin/init

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -47,10 +47,10 @@ cmd_create() {
     cmd_stop
     docker rm $CONTAINER 2>/dev/null
     docker create --name=$CONTAINER \
-        -v "$(dirname $(pwd))":/own-mailbox \
+        -v "$(pwd)":/own-mailbox \
         -w /own-mailbox/ \
         -p 80:80 -p 443:443 \
-        $IMAGE /sbin/init
+        $IMAGE ./init.sh
         #--privileged=true \
 }
 

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+### Simulate /sbin/init in docker containers
+
+for service in /etc/rc3.d/S* ; do
+    service=$(basename $service)
+    service=${service:3}
+    /etc/init.d/$service start
+done
+
+exec /sbin/init


### PR DESCRIPTION
This is a workaround for starting services in the docker container. The script `init.sh` will run on a docker container and start all the services. However it will be ignored on a real VM or a real machine.
